### PR TITLE
Fix Electron development startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "server": "node server/index.js",
     "start": "concurrently \"npm run server\" \"npm run dev\"",
     "electron": "electron .",
-    "electron:dev": "concurrently \"npm run server\" \"wait-on http://localhost:3001 && electron .\"",
+    "electron:dev": "concurrently \"npm run server\" \"node scripts/wait-for-server.js http://localhost:3001 && electron .\"",
     "electron:build": "npm run build && electron-builder",
     "electron:build:linux": "npm run build && electron-builder --linux",
     "electron:build:win": "npm run build && electron-builder --win",

--- a/scripts/wait-for-server.js
+++ b/scripts/wait-for-server.js
@@ -1,0 +1,32 @@
+const http = require("node:http");
+const https = require("node:https");
+
+const target = new URL(process.argv[2] || "http://localhost:3001");
+const timeoutMs = Number(process.env.WAIT_FOR_SERVER_TIMEOUT_MS || 60_000);
+const intervalMs = 500;
+const startedAt = Date.now();
+const client = target.protocol === "https:" ? https : http;
+
+function check() {
+  const request = client.get(target, (response) => {
+    response.resume();
+    if (response.statusCode && response.statusCode < 500) {
+      process.stdout.write(`Server ready at ${target}\n`);
+      process.exit(0);
+    }
+    retry();
+  });
+
+  request.setTimeout(2_000, () => request.destroy());
+  request.on("error", retry);
+}
+
+function retry() {
+  if (Date.now() - startedAt >= timeoutMs) {
+    process.stderr.write(`Timed out waiting for ${target}\n`);
+    process.exit(1);
+  }
+  setTimeout(check, intervalMs);
+}
+
+check();


### PR DESCRIPTION
## What changed

- Replaces the undeclared `wait-on` command in `npm run electron:dev` with a small dependency-free Node readiness check.
- Waits up to 60 seconds for the local server before launching Electron.
- Exits with a clear error when the server never becomes ready.

## Verification

- `node --check scripts/wait-for-server.js`
- Integration-tested the helper against a temporary local HTTP server.

Created as a draft so the application build can be reviewed before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development startup reliability by waiting for the local server to become available before launching the desktop app.
  * Added retry handling, request timeouts, and an overall startup timeout to provide clearer behavior when the server is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->