### PR TITLE
Complete guarded chat document and web tools

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,10 @@ const cors = require('cors');
 const bodyParser = require('body-parser');
 const dotenv = require('dotenv');
 const http = require('http');
+const dns = require('dns').promises;
+const net = require('net');
 const { Server } = require('socket.io');
+const cheerio = require('cheerio');
 const LocalAIEngine = require('./ai-engine/LocalAIEngine');
 const PluginSystem = require('./ai-engine/PluginSystem');
 const CodeIntelligence = require('./ai-engine/CodeIntelligence');
@@ -193,6 +196,106 @@ app.get('/api/skills', async (req, res) => {
 app.get('/api/skills/export', async (req, res) => {
   await pluginSystemReady;
   res.json({ success: true, skills: await pluginSystem.exportSkills() });
+});
+
+app.post('/api/process-document', (req, res) => {
+  try {
+    const { name = 'document', type = 'text/plain', size = 0, content = '' } = req.body;
+    if (typeof content !== 'string' || !content) {
+      return res.status(400).json({ success: false, error: 'Document content is required' });
+    }
+
+    const isImage = type.startsWith('image/');
+    const text = isImage
+      ? `Image received: ${name} (${type}, ${size} bytes). OCR is not configured.`
+      : content.slice(0, 100000);
+
+    res.json({
+      success: true,
+      analysis: text,
+      metadata: { name, type, size, truncated: !isImage && content.length > 100000 },
+      mode: 'offline'
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+function isPrivateAddress(address) {
+  if (net.isIP(address) === 4) {
+    const parts = address.split('.').map(Number);
+    return parts[0] === 10
+      || parts[0] === 127
+      || (parts[0] === 169 && parts[1] === 254)
+      || (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31)
+      || (parts[0] === 192 && parts[1] === 168)
+      || parts[0] === 0;
+  }
+
+  const normalized = address.toLowerCase();
+  return normalized === '::1'
+    || normalized === '::'
+    || normalized.startsWith('fc')
+    || normalized.startsWith('fd')
+    || normalized.startsWith('fe80:');
+}
+
+async function validatePublicUrl(value) {
+  const url = new URL(value);
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('Only HTTP and HTTPS URLs are supported');
+  }
+
+  const addresses = await dns.lookup(url.hostname, { all: true });
+  if (!addresses.length || addresses.some(({ address }) => isPrivateAddress(address))) {
+    throw new Error('Private and local network addresses are not allowed');
+  }
+  return url;
+}
+
+app.post('/api/crawl', async (req, res) => {
+  try {
+    let url = await validatePublicUrl(req.body.url);
+    let response;
+
+    for (let redirects = 0; redirects <= 3; redirects += 1) {
+      response = await fetch(url, {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(10000),
+        headers: { 'User-Agent': 'AgentFoundry/1.0' }
+      });
+
+      if (![301, 302, 303, 307, 308].includes(response.status)) break;
+      const location = response.headers.get('location');
+      if (!location || redirects === 3) throw new Error('Too many redirects');
+      url = await validatePublicUrl(new URL(location, url).toString());
+    }
+
+    if (!response.ok) throw new Error(`Remote server returned HTTP ${response.status}`);
+    const contentLength = Number(response.headers.get('content-length') || 0);
+    if (contentLength > 2_000_000) throw new Error('Remote response is too large');
+
+    const html = (await response.text()).slice(0, 2_000_000);
+    const $ = cheerio.load(html);
+    $('script, style, noscript').remove();
+    res.json({
+      success: true,
+      url: url.toString(),
+      title: $('title').first().text().trim(),
+      text: $('body').text().replace(/\s+/g, ' ').trim().slice(0, 10000),
+      truncated: html.length === 2_000_000
+    });
+  } catch (error) {
+    const status = error.name === 'TimeoutError' ? 504 : 400;
+    res.status(status).json({ success: false, error: error.message });
+  }
+});
+
+app.post('/api/chatgpt2/execute', (req, res) => {
+  res.status(501).json({
+    success: false,
+    error: 'Code execution is disabled because no secure sandbox is configured'
+  });
 });
 
 // Main chat endpoint

--- a/src/components/ChatGPT2.jsx
+++ b/src/components/ChatGPT2.jsx
@@ -20,32 +20,30 @@ const ChatGPT2 = () => {
       role: 'assistant',
       content: `# Welcome to ChatGPT 2.0 UNRESTRICTED! 🚀
 
-I'm your ultimate AI assistant with **ZERO RESTRICTIONS** and **ALL FEATURES**:
+I'm your self-hosted AI workspace with online and offline tools:
 
 ## 🎯 What I Can Do:
-- 💬 **Unlimited Chat** - No filters, no restrictions
-- 🌐 **Real-time Web Browsing** - Search and crawl any website
+- 💬 **Local Chat** - Connect your preferred providers with environment keys
+- 🌐 **Web Tools** - Search and crawl public websites when configured
 - 🎨 **Image Generation** - DALL-E 3, Stable Diffusion XL
 - 🎬 **Video Generation** - Create videos from text/images
 - 🎵 **Audio & Music** - TTS, voice cloning, music generation
-- 📄 **Document Processing** - PDF, DOCX, images (OCR)
-- 💻 **Code Execution** - Run code directly
-- 📁 **File System Access** - Read/write files
+- 📄 **Document Processing** - Inspect text documents locally
+- 💻 **Code Assistance** - Analyze, explain, refactor, and format code
 - 🐙 **GitHub Integration** - Manage repos, PRs, issues
 - 🧠 **Persistent Memory** - Remember across conversations
 - 🎭 **Multiple Personalities** - Different AI modes
 - 🔒 **100% Offline Mode** - Works without internet
 
-## 🔥 Unique Features ChatGPT Can't Do:
-✓ Unrestricted content generation
-✓ Direct file system access
-✓ Real-time web browsing
-✓ GitHub API integration
-✓ Multi-modal creation (image/video/audio)
-✓ Code execution without sandboxing
-✓ Complete privacy (self-hosted)
+## 🔥 Workspace Features:
+✓ Offline code intelligence
+✓ Guarded public-web crawling
+✓ Optional GitHub and AI-provider integrations
+✓ Multi-modal provider hooks (image/video/audio)
+✓ Local conversation storage
+✓ Self-hosted privacy controls
 
-**Try me!** Ask anything, generate anything, do anything! 😎`,
+**Try me!** Ask a question, upload a text file, or switch to the code editor. 😎`,
       timestamp: new Date(),
       type: 'text'
     }
@@ -150,15 +148,19 @@ I'm your ultimate AI assistant with **ZERO RESTRICTIONS** and **ALL FEATURES**:
     setIsLoading(true);
 
     try {
-      const formData = new FormData();
-      formData.append('file', file);
-
       const response = await fetch('/api/process-document', {
         method: 'POST',
-        body: formData
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: file.name,
+          type: file.type,
+          size: file.size,
+          content
+        })
       });
 
       const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Document processing failed');
       
       const aiMessage = {
         id: Date.now() + 1,
@@ -378,6 +380,7 @@ I'm your ultimate AI assistant with **ZERO RESTRICTIONS** and **ALL FEATURES**:
     });
 
     const data = await response.json();
+    if (!response.ok) throw new Error(data.error || 'Web crawl failed');
     
     const aiMessage = {
       id: Date.now() + 2,
@@ -398,6 +401,7 @@ I'm your ultimate AI assistant with **ZERO RESTRICTIONS** and **ALL FEATURES**:
     });
 
     const data = await response.json();
+    if (!response.ok) throw new Error(data.error || 'Code execution is unavailable');
     
     const aiMessage = {
       id: Date.now() + 1,


### PR DESCRIPTION
## What changed

- send uploaded text/image metadata to the server as JSON and process text documents offline
- add guarded public HTTP/HTTPS crawling with DNS-based private-network blocking, redirect revalidation, timeouts, and response-size limits
- return an explicit 501 response for code execution until a secure sandbox is configured
- surface API failures in the chat UI
- replace misleading unrestricted/host-access claims with the capabilities the app currently provides

## Security

The existing `ChatGPT2_Unrestricted.executeCode` implementation evaluates submitted JavaScript with host process access. This PR intentionally does not expose it over HTTP. Local and private network crawl targets are also rejected to reduce SSRF risk.

## Validation

- `node --check server/index.js`
- `npm run build`
- document text processing returns HTTP 200
- empty document payload returns HTTP 400
- localhost crawl target returns HTTP 400
- non-HTTP URL returns HTTP 400
- code execution returns HTTP 501 with a secure-sandbox explanation
- `git diff --check`

A live crawl of `https://example.com` could not resolve in the current restricted container (`EAI_AGAIN`); the validation and rejection paths were exercised locally.