### PR TITLE
test: harden guarded chat tools and error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,11 @@ jobs:
           node --check electron.js
           node --check preload.js
           node --check server/index.js
+          node --check server/chat-tools.js
           node --check scripts/wait-for-server.js
+
+      - name: Test guarded chat tools
+        run: npm test
 
       - name: Build web application
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-pro",
   "productName": "Copilot Pro",
   "version": "1.0.0",
-  "description": "Advanced Offline AI Copilot Pro - Professional Grade AI Coding Assistant",
+  "description": "Local-first AI coding workspace with guarded web and document tools",
   "main": "electron.js",
   "homepage": "https://github.com/SpidermanTotro/AgentFoundry-instantly",
   "author": {
@@ -30,7 +30,8 @@
     "docker:build": "docker build -t copilot-pro:latest .",
     "docker:run": "docker-compose up -d",
     "docker:stop": "docker-compose down",
-    "docker:logs": "docker-compose logs -f"
+    "docker:logs": "docker-compose logs -f",
+    "test": "node --test test/*.test.js test/*.test.mjs"
   },
   "build": {
     "appId": "com.copilotpro.app",
@@ -73,7 +74,7 @@
       "maintainer": "Copilot Pro Team <support@copilotpro.dev>",
       "vendor": "Copilot Pro",
       "synopsis": "Advanced Offline AI Coding Assistant",
-      "description": "ChatGPT 2.0 UNRESTRICTED - Professional-grade AI coding assistant with zero restrictions. Features include unlimited chat, web browsing, multi-modal AI (image/video/audio generation), code execution, file system access, and complete offline mode."
+      "description": "Self-hosted AI coding workspace with offline code assistance, guarded public-web crawling, local document inspection, and optional provider integrations."
     },
     "win": {
       "target": [

--- a/server/chat-tools.js
+++ b/server/chat-tools.js
@@ -1,18 +1,22 @@
 'use strict';
 
 const dns = require('node:dns').promises;
+const http = require('node:http');
+const https = require('node:https');
 const net = require('node:net');
 
 const DOCUMENT_TEXT_LIMIT = 100_000;
 const WEB_RESPONSE_LIMIT = 2_000_000;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
+/** Create a client-safe HTTP 400 error. */
 function badRequest(message) {
   const error = new Error(message);
   error.statusCode = 400;
   return error;
 }
 
+/** Analyze a local document payload without sending its contents elsewhere. */
 function analyzeDocument(payload = {}) {
   if (!payload || typeof payload !== 'object') {
     throw badRequest('Document payload is required');
@@ -49,6 +53,7 @@ function analyzeDocument(payload = {}) {
   };
 }
 
+/** Return true when an address is invalid, private, local, or reserved. */
 function isPrivateAddress(address) {
   if (typeof address !== 'string') return true;
 
@@ -84,7 +89,17 @@ function isPrivateAddress(address) {
   return true;
 }
 
-async function validatePublicUrl(value, options = {}) {
+/** Normalize a URL hostname for local-host and IP checks. */
+function normalizeHostname(hostname) {
+  const normalized = hostname.toLowerCase();
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    return normalized.slice(1, -1);
+  }
+  return normalized.replace(/\.$/, '');
+}
+
+/** Validate a public URL and select one already-vetted DNS address. */
+async function resolvePublicUrl(value, options = {}) {
   let url;
   try {
     url = new URL(value);
@@ -99,43 +114,119 @@ async function validatePublicUrl(value, options = {}) {
     throw badRequest('URLs containing credentials are not allowed');
   }
 
-  const hostname = url.hostname.toLowerCase();
+  const hostname = normalizeHostname(url.hostname);
   if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
     throw badRequest('Private and local network addresses are not allowed');
   }
 
   const lookup = options.lookup || dns.lookup;
-  const addresses = await lookup(hostname, { all: true });
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
   if (!Array.isArray(addresses)
       || addresses.length === 0
-      || addresses.some(({ address }) => isPrivateAddress(address))) {
+      || addresses.some((entry) => !entry || isPrivateAddress(entry.address))) {
     throw badRequest('Private and local network addresses are not allowed');
   }
 
+  const selected = addresses[0];
+  return {
+    url,
+    hostname,
+    address: selected.address,
+    family: Number(selected.family) || net.isIP(selected.address)
+  };
+}
+
+/** Validate a URL while preserving the original URL-returning API. */
+async function validatePublicUrl(value, options = {}) {
+  const { url } = await resolvePublicUrl(value, options);
   return url;
 }
 
+/** Build a Node lookup callback that can return only one vetted address. */
+function createPinnedLookup(address, family) {
+  return (_hostname, options, callback) => {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+    if (options && options.all) {
+      callback(null, [{ address, family }]);
+      return;
+    }
+    callback(null, address, family);
+  };
+}
+
+/** Perform one HTTP request with DNS pinned to a previously vetted address. */
+function requestPinned(url, options = {}) {
+  if (typeof options.lookup !== 'function') {
+    return Promise.reject(new Error('A pinned DNS lookup is required'));
+  }
+
+  const client = url.protocol === 'https:' ? https : http;
+  const headers = { ...options.headers };
+  const hasHostHeader = Object.keys(headers).some((name) => name.toLowerCase() === 'host');
+  if (!hasHostHeader) headers.Host = url.host;
+
+  return new Promise((resolve, reject) => {
+    const request = client.request(url, {
+      method: 'GET',
+      headers,
+      lookup: options.lookup,
+      servername: options.servername,
+      signal: options.signal
+    }, (response) => {
+      resolve({
+        status: response.statusCode || 0,
+        ok: response.statusCode >= 200 && response.statusCode < 300,
+        headers: {
+          get(name) {
+            const value = response.headers[name.toLowerCase()];
+            if (Array.isArray(value)) return value.join(', ');
+            return value === undefined ? null : String(value);
+          }
+        },
+        body: response
+      });
+    });
+
+    request.once('error', reject);
+    request.end();
+  });
+}
+
+/** Read a Web or Node response stream without exceeding the byte limit. */
 async function readResponseText(response, maxBytes) {
   const declaredLength = Number(response.headers.get('content-length') || 0);
   if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
     throw badRequest('Remote response is too large');
   }
 
-  if (!response.body || typeof response.body.getReader !== 'function') {
-    const buffer = Buffer.from(await response.text());
-    return {
-      text: buffer.subarray(0, maxBytes).toString('utf8'),
-      truncated: buffer.length > maxBytes
+  let iterator;
+  let cancel;
+  if (response.body && typeof response.body.getReader === 'function') {
+    const reader = response.body.getReader();
+    iterator = { next: () => reader.read() };
+    cancel = () => reader.cancel();
+  } else if (response.body && typeof response.body[Symbol.asyncIterator] === 'function') {
+    iterator = response.body[Symbol.asyncIterator]();
+    cancel = () => {
+      if (typeof response.body.destroy === 'function') {
+        response.body.destroy();
+        return undefined;
+      }
+      return typeof iterator.return === 'function' ? iterator.return() : undefined;
     };
+  } else {
+    throw badRequest('Remote response cannot be safely streamed');
   }
 
-  const reader = response.body.getReader();
   const chunks = [];
   let bytesRead = 0;
   let truncated = false;
 
   while (true) {
-    const { done, value } = await reader.read();
+    const { done, value } = await iterator.next();
     if (done) break;
 
     const chunk = Buffer.from(value);
@@ -144,7 +235,7 @@ async function readResponseText(response, maxBytes) {
       if (remaining > 0) chunks.push(chunk.subarray(0, remaining));
       truncated = true;
       try {
-        await reader.cancel();
+        await cancel();
       } catch {
         // The size cap has already been enforced; cancellation is best effort.
       }
@@ -158,26 +249,31 @@ async function readResponseText(response, maxBytes) {
   return { text: Buffer.concat(chunks).toString('utf8'), truncated };
 }
 
+/** Fetch bounded public HTML while revalidating and pinning every redirect. */
 async function fetchPublicHtml(value, options = {}) {
   const lookup = options.lookup || dns.lookup;
-  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const requestImpl = options.fetchImpl || requestPinned;
   const timeoutMs = options.timeoutMs || 10_000;
   const maxBytes = options.maxBytes || WEB_RESPONSE_LIMIT;
   const maxRedirects = options.maxRedirects ?? 3;
   const makeSignal = options.makeSignal || ((milliseconds) => AbortSignal.timeout(milliseconds));
 
-  if (typeof fetchImpl !== 'function') {
-    throw new Error('Fetch is not available');
+  if (typeof requestImpl !== 'function') {
+    throw new Error('HTTP transport is not available');
   }
 
-  let url = await validatePublicUrl(value, { lookup });
+  let target = await resolvePublicUrl(value, { lookup });
   let response;
 
   for (let redirects = 0; ; redirects += 1) {
-    response = await fetchImpl(url, {
+    response = await requestImpl(target.url, {
       redirect: 'manual',
       signal: makeSignal(timeoutMs),
-      headers: { 'User-Agent': 'AgentFoundry/1.0' }
+      headers: { 'User-Agent': 'AgentFoundry/1.0' },
+      lookup: createPinnedLookup(target.address, target.family),
+      address: target.address,
+      family: target.family,
+      servername: net.isIP(target.hostname) ? undefined : target.hostname
     });
 
     if (!REDIRECT_STATUSES.has(response.status)) break;
@@ -185,7 +281,7 @@ async function fetchPublicHtml(value, options = {}) {
     if (!location || redirects >= maxRedirects) {
       throw badRequest('Too many redirects');
     }
-    url = await validatePublicUrl(new URL(location, url).toString(), { lookup });
+    target = await resolvePublicUrl(new URL(location, target.url).toString(), { lookup });
   }
 
   if (!response.ok) {
@@ -193,15 +289,18 @@ async function fetchPublicHtml(value, options = {}) {
   }
 
   const { text: html, truncated } = await readResponseText(response, maxBytes);
-  return { url: url.toString(), html, truncated };
+  return { url: target.url.toString(), html, truncated };
 }
 
 module.exports = {
   DOCUMENT_TEXT_LIMIT,
   WEB_RESPONSE_LIMIT,
   analyzeDocument,
+  createPinnedLookup,
   fetchPublicHtml,
   isPrivateAddress,
   readResponseText,
+  requestPinned,
+  resolvePublicUrl,
   validatePublicUrl
 };

--- a/server/chat-tools.js
+++ b/server/chat-tools.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const dns = require('node:dns').promises;
+const net = require('node:net');
+
+const DOCUMENT_TEXT_LIMIT = 100_000;
+const WEB_RESPONSE_LIMIT = 2_000_000;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function badRequest(message) {
+  const error = new Error(message);
+  error.statusCode = 400;
+  return error;
+}
+
+function analyzeDocument(payload = {}) {
+  if (!payload || typeof payload !== 'object') {
+    throw badRequest('Document payload is required');
+  }
+
+  const {
+    name = 'document',
+    type = 'text/plain',
+    size = 0,
+    content = ''
+  } = payload;
+
+  if (typeof content !== 'string' || content.length === 0) {
+    throw badRequest('Document content is required');
+  }
+
+  const safeName = typeof name === 'string' && name ? name : 'document';
+  const safeType = typeof type === 'string' && type ? type : 'text/plain';
+  const safeSize = Number.isFinite(size) && size >= 0 ? size : 0;
+  const isImage = safeType.startsWith('image/');
+  const analysis = isImage
+    ? `Image received: ${safeName} (${safeType}, ${safeSize} bytes). OCR is not configured.`
+    : content.slice(0, DOCUMENT_TEXT_LIMIT);
+
+  return {
+    analysis,
+    metadata: {
+      name: safeName,
+      type: safeType,
+      size: safeSize,
+      truncated: !isImage && content.length > DOCUMENT_TEXT_LIMIT
+    },
+    mode: 'offline'
+  };
+}
+
+function isPrivateAddress(address) {
+  if (typeof address !== 'string') return true;
+
+  const normalized = address.toLowerCase().split('%')[0];
+  const mappedIpv4 = normalized.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (mappedIpv4) return isPrivateAddress(mappedIpv4[1]);
+
+  const version = net.isIP(normalized);
+  if (version === 4) {
+    const [a, b] = normalized.split('.').map(Number);
+    return a === 0
+      || a === 10
+      || a === 127
+      || (a === 100 && b >= 64 && b <= 127)
+      || (a === 169 && b === 254)
+      || (a === 172 && b >= 16 && b <= 31)
+      || (a === 192 && b === 0)
+      || (a === 192 && b === 168)
+      || (a === 198 && (b === 18 || b === 19))
+      || a >= 224;
+  }
+
+  if (version === 6) {
+    return normalized === '::'
+      || normalized === '::1'
+      || normalized.startsWith('fc')
+      || normalized.startsWith('fd')
+      || /^fe[89ab]/.test(normalized)
+      || normalized.startsWith('ff')
+      || normalized.startsWith('2001:db8:');
+  }
+
+  return true;
+}
+
+async function validatePublicUrl(value, options = {}) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw badRequest('A valid URL is required');
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw badRequest('Only HTTP and HTTPS URLs are supported');
+  }
+  if (url.username || url.password) {
+    throw badRequest('URLs containing credentials are not allowed');
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+    throw badRequest('Private and local network addresses are not allowed');
+  }
+
+  const lookup = options.lookup || dns.lookup;
+  const addresses = await lookup(hostname, { all: true });
+  if (!Array.isArray(addresses)
+      || addresses.length === 0
+      || addresses.some(({ address }) => isPrivateAddress(address))) {
+    throw badRequest('Private and local network addresses are not allowed');
+  }
+
+  return url;
+}
+
+async function readResponseText(response, maxBytes) {
+  const declaredLength = Number(response.headers.get('content-length') || 0);
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw badRequest('Remote response is too large');
+  }
+
+  if (!response.body || typeof response.body.getReader !== 'function') {
+    const buffer = Buffer.from(await response.text());
+    return {
+      text: buffer.subarray(0, maxBytes).toString('utf8'),
+      truncated: buffer.length > maxBytes
+    };
+  }
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let bytesRead = 0;
+  let truncated = false;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    const chunk = Buffer.from(value);
+    const remaining = maxBytes - bytesRead;
+    if (chunk.length > remaining) {
+      if (remaining > 0) chunks.push(chunk.subarray(0, remaining));
+      truncated = true;
+      try {
+        await reader.cancel();
+      } catch {
+        // The size cap has already been enforced; cancellation is best effort.
+      }
+      break;
+    }
+
+    chunks.push(chunk);
+    bytesRead += chunk.length;
+  }
+
+  return { text: Buffer.concat(chunks).toString('utf8'), truncated };
+}
+
+async function fetchPublicHtml(value, options = {}) {
+  const lookup = options.lookup || dns.lookup;
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const timeoutMs = options.timeoutMs || 10_000;
+  const maxBytes = options.maxBytes || WEB_RESPONSE_LIMIT;
+  const maxRedirects = options.maxRedirects ?? 3;
+  const makeSignal = options.makeSignal || ((milliseconds) => AbortSignal.timeout(milliseconds));
+
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('Fetch is not available');
+  }
+
+  let url = await validatePublicUrl(value, { lookup });
+  let response;
+
+  for (let redirects = 0; ; redirects += 1) {
+    response = await fetchImpl(url, {
+      redirect: 'manual',
+      signal: makeSignal(timeoutMs),
+      headers: { 'User-Agent': 'AgentFoundry/1.0' }
+    });
+
+    if (!REDIRECT_STATUSES.has(response.status)) break;
+    const location = response.headers.get('location');
+    if (!location || redirects >= maxRedirects) {
+      throw badRequest('Too many redirects');
+    }
+    url = await validatePublicUrl(new URL(location, url).toString(), { lookup });
+  }
+
+  if (!response.ok) {
+    throw badRequest(`Remote server returned HTTP ${response.status}`);
+  }
+
+  const { text: html, truncated } = await readResponseText(response, maxBytes);
+  return { url: url.toString(), html, truncated };
+}
+
+module.exports = {
+  DOCUMENT_TEXT_LIMIT,
+  WEB_RESPONSE_LIMIT,
+  analyzeDocument,
+  fetchPublicHtml,
+  isPrivateAddress,
+  readResponseText,
+  validatePublicUrl
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * ChatGPT 2.0 UNRESTRICTED - Complete Unified Server
+ * AgentFoundry Instantly - Complete Unified Server
  * Merges: Authentication + Vector DB + WebSocket + AI Engines
  */
 
@@ -9,10 +9,9 @@ const cors = require('cors');
 const bodyParser = require('body-parser');
 const dotenv = require('dotenv');
 const http = require('http');
-const dns = require('dns').promises;
-const net = require('net');
 const { Server } = require('socket.io');
 const cheerio = require('cheerio');
+const { analyzeDocument, fetchPublicHtml } = require('./chat-tools');
 const LocalAIEngine = require('./ai-engine/LocalAIEngine');
 const PluginSystem = require('./ai-engine/PluginSystem');
 const CodeIntelligence = require('./ai-engine/CodeIntelligence');
@@ -62,7 +61,7 @@ app.use((req, res, next) => {
 });
 
 // Initialize services
-console.log('\n🚀 ChatGPT 2.0 UNRESTRICTED - Complete Server Starting...\n');
+console.log('\n🚀 AgentFoundry Instantly - Complete Server Starting...\n');
 
 (async () => {
   try {
@@ -90,7 +89,7 @@ app.use('/api/vectordb', vectordbRoutes);
 app.get('/api/health', (req, res) => {
   res.json({
     status: 'ok',
-    message: 'ChatGPT 2.0 UNRESTRICTED - All Systems Ready',
+    message: 'AgentFoundry Instantly - All Systems Ready',
     timestamp: new Date().toISOString(),
     features: {
       authentication: true,
@@ -200,93 +199,28 @@ app.get('/api/skills/export', async (req, res) => {
 
 app.post('/api/process-document', (req, res) => {
   try {
-    const { name = 'document', type = 'text/plain', size = 0, content = '' } = req.body;
-    if (typeof content !== 'string' || !content) {
-      return res.status(400).json({ success: false, error: 'Document content is required' });
-    }
-
-    const isImage = type.startsWith('image/');
-    const text = isImage
-      ? `Image received: ${name} (${type}, ${size} bytes). OCR is not configured.`
-      : content.slice(0, 100000);
-
-    res.json({
-      success: true,
-      analysis: text,
-      metadata: { name, type, size, truncated: !isImage && content.length > 100000 },
-      mode: 'offline'
-    });
+    res.json({ success: true, ...analyzeDocument(req.body) });
   } catch (error) {
-    res.status(500).json({ success: false, error: error.message });
+    res.status(error.statusCode || 500).json({ success: false, error: error.message });
   }
 });
 
-function isPrivateAddress(address) {
-  if (net.isIP(address) === 4) {
-    const parts = address.split('.').map(Number);
-    return parts[0] === 10
-      || parts[0] === 127
-      || (parts[0] === 169 && parts[1] === 254)
-      || (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31)
-      || (parts[0] === 192 && parts[1] === 168)
-      || parts[0] === 0;
-  }
-
-  const normalized = address.toLowerCase();
-  return normalized === '::1'
-    || normalized === '::'
-    || normalized.startsWith('fc')
-    || normalized.startsWith('fd')
-    || normalized.startsWith('fe80:');
-}
-
-async function validatePublicUrl(value) {
-  const url = new URL(value);
-  if (!['http:', 'https:'].includes(url.protocol)) {
-    throw new Error('Only HTTP and HTTPS URLs are supported');
-  }
-
-  const addresses = await dns.lookup(url.hostname, { all: true });
-  if (!addresses.length || addresses.some(({ address }) => isPrivateAddress(address))) {
-    throw new Error('Private and local network addresses are not allowed');
-  }
-  return url;
-}
-
 app.post('/api/crawl', async (req, res) => {
   try {
-    let url = await validatePublicUrl(req.body.url);
-    let response;
-
-    for (let redirects = 0; redirects <= 3; redirects += 1) {
-      response = await fetch(url, {
-        redirect: 'manual',
-        signal: AbortSignal.timeout(10000),
-        headers: { 'User-Agent': 'AgentFoundry/1.0' }
-      });
-
-      if (![301, 302, 303, 307, 308].includes(response.status)) break;
-      const location = response.headers.get('location');
-      if (!location || redirects === 3) throw new Error('Too many redirects');
-      url = await validatePublicUrl(new URL(location, url).toString());
-    }
-
-    if (!response.ok) throw new Error(`Remote server returned HTTP ${response.status}`);
-    const contentLength = Number(response.headers.get('content-length') || 0);
-    if (contentLength > 2_000_000) throw new Error('Remote response is too large');
-
-    const html = (await response.text()).slice(0, 2_000_000);
+    const { url, html, truncated } = await fetchPublicHtml(req.body.url);
     const $ = cheerio.load(html);
     $('script, style, noscript').remove();
     res.json({
       success: true,
-      url: url.toString(),
+      url,
       title: $('title').first().text().trim(),
       text: $('body').text().replace(/\s+/g, ' ').trim().slice(0, 10000),
-      truncated: html.length === 2_000_000
+      truncated
     });
   } catch (error) {
-    const status = error.name === 'TimeoutError' ? 504 : 400;
+    const status = ['TimeoutError', 'AbortError'].includes(error.name)
+      ? 504
+      : (error.statusCode || 400);
     res.status(status).json({ success: false, error: error.message });
   }
 });
@@ -452,9 +386,9 @@ app.use((req, res) => {
 // Start server
 server.listen(PORT, () => {
   console.log('\n═══════════════════════════════════════════════════════════');
-  console.log('  🚀 ChatGPT 2.0 UNRESTRICTED - Server ONLINE');
+  console.log('  🚀 AgentFoundry Instantly - Server ONLINE');
   console.log('═══════════════════════════════════════════════════════════');
-  console.log(`\n  Mode: Complete Unified Server`);
+  console.log(`\n  Mode: Local and guarded unified server`);
   console.log(`  Port: ${PORT}`);
   console.log(`  Environment: ${process.env.NODE_ENV || 'development'}`);
   console.log('\n  ✅ Features Enabled:');

--- a/server/index.js
+++ b/server/index.js
@@ -199,7 +199,7 @@ app.get('/api/skills/export', async (req, res) => {
 
 app.post('/api/process-document', (req, res) => {
   try {
-    res.json({ success: true, ...analyzeDocument(req.body) });
+    res.json({ success: true, data: analyzeDocument(req.body) });
   } catch (error) {
     res.status(error.statusCode || 500).json({ success: false, error: error.message });
   }
@@ -212,10 +212,12 @@ app.post('/api/crawl', async (req, res) => {
     $('script, style, noscript').remove();
     res.json({
       success: true,
-      url,
-      title: $('title').first().text().trim(),
-      text: $('body').text().replace(/\s+/g, ' ').trim().slice(0, 10000),
-      truncated
+      data: {
+        url,
+        title: $('title').first().text().trim(),
+        text: $('body').text().replace(/\s+/g, ' ').trim().slice(0, 10000),
+        truncated
+      }
     });
   } catch (error) {
     const status = ['TimeoutError', 'AbortError'].includes(error.name)

--- a/src/components/ChatGPT2.jsx
+++ b/src/components/ChatGPT2.jsx
@@ -386,7 +386,9 @@ I'm your self-hosted AI workspace with online and offline tools:
       type: 'text'
     };
     
-    setMessages(prev => [...prev.slice(0, -1), aiMessage]);
+    setMessages(prev => prev.map(message =>
+      message.id === loadingMsg.id ? aiMessage : message
+    ));
   };
 
   const executeCode = async (code) => {

--- a/src/components/ChatGPT2.jsx
+++ b/src/components/ChatGPT2.jsx
@@ -11,6 +11,7 @@ import {
   FaEdit, FaCodeBranch, FaUpload, FaFileExport
 } from 'react-icons/fa';
 import conversationManager from '../utils/ConversationManager';
+import { crawlUrl, executeCodeRequest, processDocumentRequest } from '../utils/chatApi.mjs';
 import './ChatGPT2.css';
 
 const ChatGPT2 = () => {
@@ -18,7 +19,7 @@ const ChatGPT2 = () => {
     {
       id: 1,
       role: 'assistant',
-      content: `# Welcome to ChatGPT 2.0 UNRESTRICTED! 🚀
+      content: `# Welcome to AgentFoundry Instantly! 🚀
 
 I'm your self-hosted AI workspace with online and offline tools:
 
@@ -54,7 +55,7 @@ I'm your self-hosted AI workspace with online and offline tools:
   const [mode, setMode] = useState('chat');
   const [showSidebar, setShowSidebar] = useState(true);
   const [conversations, setConversations] = useState([
-    { id: 1, title: 'ChatGPT 2.0 UNRESTRICTED', date: new Date() }
+    { id: 1, title: 'AgentFoundry Instantly', date: new Date() }
   ]);
   const [currentConversationId, setCurrentConversationId] = useState(1);
   const [isRecording, setIsRecording] = useState(false);
@@ -148,19 +149,7 @@ I'm your self-hosted AI workspace with online and offline tools:
     setIsLoading(true);
 
     try {
-      const response = await fetch('/api/process-document', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: file.name,
-          type: file.type,
-          size: file.size,
-          content
-        })
-      });
-
-      const data = await response.json();
-      if (!response.ok) throw new Error(data.error || 'Document processing failed');
+      const data = await processDocumentRequest(file, content);
       
       const aiMessage = {
         id: Date.now() + 1,
@@ -173,6 +162,14 @@ I'm your self-hosted AI workspace with online and offline tools:
       setMessages(prev => [...prev, aiMessage]);
     } catch (error) {
       console.error('Error processing document:', error);
+      const errorMessage = {
+        id: Date.now() + 1,
+        role: 'assistant',
+        content: `❌ Error processing document: ${error.message}`,
+        timestamp: new Date(),
+        type: 'error'
+      };
+      setMessages(prev => [...prev, errorMessage]);
     } finally {
       setIsLoading(false);
     }
@@ -373,14 +370,13 @@ I'm your self-hosted AI workspace with online and offline tools:
     };
     setMessages(prev => [...prev, loadingMsg]);
 
-    const response = await fetch('/api/crawl', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url })
-    });
-
-    const data = await response.json();
-    if (!response.ok) throw new Error(data.error || 'Web crawl failed');
+    let data;
+    try {
+      data = await crawlUrl(url);
+    } catch (error) {
+      setMessages(prev => prev.filter(message => message.id !== loadingMsg.id));
+      throw error;
+    }
     
     const aiMessage = {
       id: Date.now() + 2,
@@ -394,14 +390,7 @@ I'm your self-hosted AI workspace with online and offline tools:
   };
 
   const executeCode = async (code) => {
-    const response = await fetch('/api/chatgpt2/execute', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code })
-    });
-
-    const data = await response.json();
-    if (!response.ok) throw new Error(data.error || 'Code execution is unavailable');
+    const data = await executeCodeRequest(code);
     
     const aiMessage = {
       id: Date.now() + 1,
@@ -732,7 +721,7 @@ I'm your self-hosted AI workspace with online and offline tools:
           <div className="header-title">
             <FaRobot className="header-icon" />
             <div>
-              <h2>ChatGPT 2.0 UNRESTRICTED</h2>
+              <h2>AgentFoundry Instantly</h2>
               <span className="header-subtitle">
                 {mode === 'chat' && '💬 Chat Mode'}
                 {mode === 'code' && '💻 Code Mode'}
@@ -793,6 +782,12 @@ I'm your self-hosted AI workspace with online and offline tools:
                   </ReactMarkdown>
                 )}
                 
+                {message.type === 'error' && (
+                  <div className="message-error" role="alert">
+                    {message.content}
+                  </div>
+                )}
+
                 {message.type === 'image' && (
                   <div className="message-media">
                     <img src={message.imageUrl} alt="Generated" />
@@ -901,7 +896,7 @@ I'm your self-hosted AI workspace with online and offline tools:
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyPress={handleKeyPress}
-              placeholder="Message ChatGPT 2.0... (try /image, /video, /audio, /search)"
+              placeholder="Message AgentFoundry... (try /image, /video, /audio, /search)"
               className="chat-input"
               rows="1"
             />

--- a/src/utils/chatApi.mjs
+++ b/src/utils/chatApi.mjs
@@ -1,9 +1,15 @@
+/** Send a JSON request and preserve the chat API's safe response contract. */
 async function requestJson(path, payload, fallbackMessage, fetchImpl = globalThis.fetch) {
-  const response = await fetchImpl(path, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
-  });
+  let response;
+  try {
+    response = await fetchImpl(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  } catch {
+    throw new Error(fallbackMessage);
+  }
 
   let data = {};
   try {
@@ -12,10 +18,10 @@ async function requestJson(path, payload, fallbackMessage, fetchImpl = globalThi
     if (response.ok) throw new Error('The server returned an invalid response');
   }
 
-  if (!response.ok) {
+  if (!response.ok || data.success === false) {
     throw new Error(data.error || fallbackMessage);
   }
-  return data;
+  return data.success === true && Object.hasOwn(data, 'data') ? data.data : data;
 }
 
 export function processDocumentRequest(file, content, fetchImpl) {

--- a/src/utils/chatApi.mjs
+++ b/src/utils/chatApi.mjs
@@ -1,0 +1,38 @@
+async function requestJson(path, payload, fallbackMessage, fetchImpl = globalThis.fetch) {
+  const response = await fetchImpl(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  let data = {};
+  try {
+    data = await response.json();
+  } catch {
+    if (response.ok) throw new Error('The server returned an invalid response');
+  }
+
+  if (!response.ok) {
+    throw new Error(data.error || fallbackMessage);
+  }
+  return data;
+}
+
+export function processDocumentRequest(file, content, fetchImpl) {
+  return requestJson('/api/process-document', {
+    name: file.name,
+    type: file.type,
+    size: file.size,
+    content
+  }, 'Document processing failed', fetchImpl);
+}
+
+export function crawlUrl(url, fetchImpl) {
+  return requestJson('/api/crawl', { url }, 'Web crawl failed', fetchImpl);
+}
+
+export function executeCodeRequest(code, fetchImpl) {
+  return requestJson('/api/chatgpt2/execute', { code }, 'Code execution is unavailable', fetchImpl);
+}
+
+export { requestJson };

--- a/test/chat-api.test.mjs
+++ b/test/chat-api.test.mjs
@@ -20,7 +20,7 @@ test('processDocumentRequest sends only the expected JSON document fields', asyn
   let captured;
   const fetchImpl = async (path, options) => {
     captured = { path, options };
-    return jsonResponse({ success: true, analysis: 'offline result' });
+    return jsonResponse({ success: true, data: { analysis: 'offline result' } });
   };
 
   const result = await processDocumentRequest({
@@ -76,5 +76,28 @@ test('requestJson uses its safe fallback for non-JSON errors', async () => {
   await assert.rejects(
     requestJson('/api/test', {}, 'Request failed safely', fetchImpl),
     /Request failed safely/
+  );
+});
+
+test('requestJson uses its safe fallback for network failures', async () => {
+  const fetchImpl = async () => {
+    throw new TypeError('Failed to fetch');
+  };
+
+  await assert.rejects(
+    requestJson('/api/test', {}, 'Request failed safely', fetchImpl),
+    /^Error: Request failed safely$/
+  );
+});
+
+test('requestJson unwraps the successful API data envelope', async () => {
+  const fetchImpl = async () => jsonResponse({
+    success: true,
+    data: { value: 'kept stable for the UI' }
+  });
+
+  assert.deepEqual(
+    await requestJson('/api/test', {}, 'Request failed safely', fetchImpl),
+    { value: 'kept stable for the UI' }
   );
 });

--- a/test/chat-api.test.mjs
+++ b/test/chat-api.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  crawlUrl,
+  executeCodeRequest,
+  processDocumentRequest,
+  requestJson
+} from '../src/utils/chatApi.mjs';
+
+function jsonResponse(data, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => data
+  };
+}
+
+test('processDocumentRequest sends only the expected JSON document fields', async () => {
+  let captured;
+  const fetchImpl = async (path, options) => {
+    captured = { path, options };
+    return jsonResponse({ success: true, analysis: 'offline result' });
+  };
+
+  const result = await processDocumentRequest({
+    name: 'notes.txt',
+    type: 'text/plain',
+    size: 7,
+    ignored: 'not serialized'
+  }, 'content', fetchImpl);
+
+  assert.equal(captured.path, '/api/process-document');
+  assert.equal(captured.options.method, 'POST');
+  assert.equal(captured.options.headers['Content-Type'], 'application/json');
+  assert.deepEqual(JSON.parse(captured.options.body), {
+    name: 'notes.txt',
+    type: 'text/plain',
+    size: 7,
+    content: 'content'
+  });
+  assert.equal(result.analysis, 'offline result');
+});
+
+test('crawlUrl surfaces the server rejection message', async () => {
+  const fetchImpl = async () => jsonResponse({
+    success: false,
+    error: 'Private and local network addresses are not allowed'
+  }, { ok: false, status: 400 });
+
+  await assert.rejects(
+    crawlUrl('http://127.0.0.1', fetchImpl),
+    /Private and local network addresses are not allowed/
+  );
+});
+
+test('executeCodeRequest surfaces the secure-sandbox explanation', async () => {
+  const fetchImpl = async () => jsonResponse({
+    success: false,
+    error: 'Code execution is disabled because no secure sandbox is configured'
+  }, { ok: false, status: 501 });
+
+  await assert.rejects(
+    executeCodeRequest('process.exit()', fetchImpl),
+    /no secure sandbox is configured/
+  );
+});
+
+test('requestJson uses its safe fallback for non-JSON errors', async () => {
+  const fetchImpl = async () => ({
+    ok: false,
+    status: 502,
+    json: async () => { throw new SyntaxError('invalid JSON'); }
+  });
+
+  await assert.rejects(
+    requestJson('/api/test', {}, 'Request failed safely', fetchImpl),
+    /Request failed safely/
+  );
+});

--- a/test/chat-tools.test.js
+++ b/test/chat-tools.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DOCUMENT_TEXT_LIMIT,
+  analyzeDocument,
+  fetchPublicHtml,
+  isPrivateAddress,
+  validatePublicUrl
+} = require('../server/chat-tools');
+
+const publicLookup = async () => [{ address: '93.184.216.34', family: 4 }];
+const noTimeout = () => undefined;
+
+test('analyzeDocument processes text locally and reports metadata', () => {
+  const result = analyzeDocument({
+    name: 'notes.txt',
+    type: 'text/plain',
+    size: 12,
+    content: 'hello world'
+  });
+
+  assert.equal(result.analysis, 'hello world');
+  assert.deepEqual(result.metadata, {
+    name: 'notes.txt',
+    type: 'text/plain',
+    size: 12,
+    truncated: false
+  });
+  assert.equal(result.mode, 'offline');
+});
+
+test('analyzeDocument rejects missing or non-string content', () => {
+  assert.throws(() => analyzeDocument({}), /Document content is required/);
+  assert.throws(() => analyzeDocument({ content: Buffer.from('secret') }), /Document content is required/);
+});
+
+test('analyzeDocument caps large text without retaining the tail', () => {
+  const marker = 'PRIVATE_TAIL';
+  const result = analyzeDocument({ content: `${'a'.repeat(DOCUMENT_TEXT_LIMIT)}${marker}` });
+
+  assert.equal(result.analysis.length, DOCUMENT_TEXT_LIMIT);
+  assert.equal(result.analysis.includes(marker), false);
+  assert.equal(result.metadata.truncated, true);
+});
+
+test('analyzeDocument describes images without echoing their data URL', () => {
+  const result = analyzeDocument({
+    name: 'photo.png',
+    type: 'image/png',
+    size: 42,
+    content: 'data:image/png;base64,PRIVATE_IMAGE_BYTES'
+  });
+
+  assert.match(result.analysis, /OCR is not configured/);
+  assert.equal(result.analysis.includes('PRIVATE_IMAGE_BYTES'), false);
+  assert.equal(result.metadata.truncated, false);
+});
+
+test('isPrivateAddress rejects local, mapped, carrier-grade, and link-local ranges', () => {
+  for (const address of [
+    '127.0.0.1',
+    '10.0.0.1',
+    '100.64.0.1',
+    '169.254.1.1',
+    '172.31.255.255',
+    '192.168.1.1',
+    '::1',
+    'fe80::1',
+    'fd00::1',
+    '::ffff:127.0.0.1'
+  ]) {
+    assert.equal(isPrivateAddress(address), true, address);
+  }
+
+  assert.equal(isPrivateAddress('8.8.8.8'), false);
+  assert.equal(isPrivateAddress('2606:4700:4700::1111'), false);
+});
+
+test('validatePublicUrl accepts public HTTP URLs and blocks unsafe forms', async () => {
+  const url = await validatePublicUrl('https://example.com/page', { lookup: publicLookup });
+  assert.equal(url.toString(), 'https://example.com/page');
+
+  await assert.rejects(
+    validatePublicUrl('file:///etc/passwd', { lookup: publicLookup }),
+    /Only HTTP and HTTPS/
+  );
+  await assert.rejects(
+    validatePublicUrl('https://user:password@example.com', { lookup: publicLookup }),
+    /credentials/
+  );
+  await assert.rejects(
+    validatePublicUrl('http://localhost:3001'),
+    /Private and local/
+  );
+});
+
+test('validatePublicUrl blocks hosts with any private DNS answer', async () => {
+  const mixedLookup = async () => [
+    { address: '93.184.216.34', family: 4 },
+    { address: '10.0.0.7', family: 4 }
+  ];
+
+  await assert.rejects(
+    validatePublicUrl('https://mixed.example', { lookup: mixedLookup }),
+    /Private and local/
+  );
+});
+
+test('fetchPublicHtml revalidates redirect destinations before following them', async () => {
+  let fetchCalls = 0;
+  const lookup = async (hostname) => [{
+    address: hostname === 'safe.example' ? '93.184.216.34' : '127.0.0.1',
+    family: 4
+  }];
+  const fetchImpl = async () => {
+    fetchCalls += 1;
+    return new Response(null, {
+      status: 302,
+      headers: { location: 'http://127.0.0.1/private' }
+    });
+  };
+
+  await assert.rejects(
+    fetchPublicHtml('https://safe.example', { lookup, fetchImpl, makeSignal: noTimeout }),
+    /Private and local/
+  );
+  assert.equal(fetchCalls, 1);
+});
+
+test('fetchPublicHtml enforces the redirect limit', async () => {
+  let fetchCalls = 0;
+  const fetchImpl = async () => {
+    fetchCalls += 1;
+    return new Response(null, { status: 302, headers: { location: '/again' } });
+  };
+
+  await assert.rejects(
+    fetchPublicHtml('https://example.com', {
+      lookup: publicLookup,
+      fetchImpl,
+      maxRedirects: 3,
+      makeSignal: noTimeout
+    }),
+    /Too many redirects/
+  );
+  assert.equal(fetchCalls, 4);
+});
+
+test('fetchPublicHtml rejects declared oversized responses', async () => {
+  const fetchImpl = async () => new Response('small body', {
+    status: 200,
+    headers: { 'content-length': '2000001' }
+  });
+
+  await assert.rejects(
+    fetchPublicHtml('https://example.com', { lookup: publicLookup, fetchImpl, makeSignal: noTimeout }),
+    /too large/
+  );
+});
+
+test('fetchPublicHtml caps streamed responses when content-length is absent', async () => {
+  const fetchImpl = async () => new Response('abcdef', { status: 200 });
+  const result = await fetchPublicHtml('https://example.com', {
+    lookup: publicLookup,
+    fetchImpl,
+    maxBytes: 5,
+    makeSignal: noTimeout
+  });
+
+  assert.equal(result.html, 'abcde');
+  assert.equal(result.truncated, true);
+});
+
+test('fetchPublicHtml preserves timeout errors for the HTTP route', async () => {
+  const timeout = new Error('The operation timed out');
+  timeout.name = 'TimeoutError';
+
+  await assert.rejects(
+    fetchPublicHtml('https://example.com', {
+      lookup: publicLookup,
+      fetchImpl: async () => { throw timeout; },
+      makeSignal: noTimeout
+    }),
+    (error) => error.name === 'TimeoutError'
+  );
+});

--- a/test/chat-tools.test.js
+++ b/test/chat-tools.test.js
@@ -2,12 +2,18 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const http = require('node:http');
+const { Readable } = require('node:stream');
 
 const {
   DOCUMENT_TEXT_LIMIT,
   analyzeDocument,
+  createPinnedLookup,
   fetchPublicHtml,
   isPrivateAddress,
+  readResponseText,
+  requestPinned,
   validatePublicUrl
 } = require('../server/chat-tools');
 
@@ -130,6 +136,73 @@ test('fetchPublicHtml revalidates redirect destinations before following them', 
   assert.equal(fetchCalls, 1);
 });
 
+test('fetchPublicHtml pins the validated DNS answer for the transport', async () => {
+  let resolverCalls = 0;
+  let connectedAddress;
+  const lookup = async () => {
+    resolverCalls += 1;
+    return resolverCalls === 1
+      ? [{ address: '93.184.216.34', family: 4 }]
+      : [{ address: '127.0.0.1', family: 4 }];
+  };
+  const fetchImpl = async (url, options) => {
+    connectedAddress = await new Promise((resolve, reject) => {
+      options.lookup(url.hostname, {}, (error, address, family) => {
+        if (error) reject(error);
+        else resolve({ address, family });
+      });
+    });
+    return new Response('<html><body>safe</body></html>', { status: 200 });
+  };
+
+  await fetchPublicHtml('https://example.com', {
+    lookup,
+    fetchImpl,
+    makeSignal: noTimeout
+  });
+
+  assert.equal(resolverCalls, 1);
+  assert.deepEqual(connectedAddress, { address: '93.184.216.34', family: 4 });
+});
+
+test('requestPinned gives the transport only the pinned lookup and original Host', async (t) => {
+  const originalRequest = http.request;
+  let requestUrl;
+  let requestOptions;
+  http.request = (url, options, onResponse) => {
+    requestUrl = url;
+    requestOptions = options;
+    const request = new EventEmitter();
+    request.end = () => {
+      const response = Readable.from([Buffer.from('pinned response')]);
+      response.statusCode = 200;
+      response.headers = { 'content-length': '15' };
+      queueMicrotask(() => onResponse(response));
+    };
+    return request;
+  };
+  t.after(() => {
+    http.request = originalRequest;
+  });
+
+  const response = await requestPinned(new URL('http://safe.example:8080/path'), {
+    lookup: createPinnedLookup('93.184.216.34', 4)
+  });
+  const result = await readResponseText(response, 100);
+  const pinned = await new Promise((resolve, reject) => {
+    requestOptions.lookup('safe.example', {}, (error, address, family) => {
+      if (error) reject(error);
+      else resolve({ address, family });
+    });
+  });
+
+  assert.equal(requestUrl.hostname, 'safe.example');
+  assert.equal(requestOptions.headers.Host, 'safe.example:8080');
+  assert.deepEqual(pinned, { address: '93.184.216.34', family: 4 });
+  assert.equal(result.text, 'pinned response');
+  assert.equal(result.truncated, false);
+});
+
 test('fetchPublicHtml enforces the redirect limit', async () => {
   let fetchCalls = 0;
   const fetchImpl = async () => {
@@ -172,6 +245,48 @@ test('fetchPublicHtml caps streamed responses when content-length is absent', as
 
   assert.equal(result.html, 'abcde');
   assert.equal(result.truncated, true);
+});
+
+test('fetchPublicHtml caps Node streams without buffering the whole body', async () => {
+  const fetchImpl = async () => ({
+    status: 200,
+    ok: true,
+    headers: { get: () => null },
+    body: Readable.from([Buffer.from('abc'), Buffer.from('def')])
+  });
+  const result = await fetchPublicHtml('https://example.com', {
+    lookup: publicLookup,
+    fetchImpl,
+    maxBytes: 5,
+    makeSignal: noTimeout
+  });
+
+  assert.equal(result.html, 'abcde');
+  assert.equal(result.truncated, true);
+});
+
+test('fetchPublicHtml fails closed when a response cannot be streamed safely', async () => {
+  let textCalled = false;
+  const fetchImpl = async () => ({
+    status: 200,
+    ok: true,
+    headers: { get: () => null },
+    body: null,
+    text: async () => {
+      textCalled = true;
+      return 'unbounded';
+    }
+  });
+
+  await assert.rejects(
+    fetchPublicHtml('https://example.com', {
+      lookup: publicLookup,
+      fetchImpl,
+      makeSignal: noTimeout
+    }),
+    /cannot be safely streamed/
+  );
+  assert.equal(textCalled, false);
 });
 
 test('fetchPublicHtml preserves timeout errors for the HTTP route', async () => {


### PR DESCRIPTION
## Summary

Adds the automated finishing-touch coverage requested after #21 and makes the guarded chat-tool boundaries directly testable.

## What changed

- extracts offline document processing and guarded public-web crawling into testable server helpers
- blocks local/private, carrier-grade NAT, link-local, multicast, IPv4-mapped loopback, credential-bearing, and mixed public/private DNS targets
- pins the already-validated DNS address in the real HTTP/TLS transport, preserving the original Host header and TLS SNI
- revalidates and pins every redirect destination
- caps Web and Node response streams even when `content-length` is absent; unstreamable bodies fail closed
- preserves the required `{ success: true, data: {...} }` API envelope while keeping UI helper results stable
- converts rejected frontend network requests into safe endpoint-specific errors
- replaces crawl loading messages by ID so concurrent messages are preserved
- displays document, crawl, and secure code-execution errors in the chat UI
- replaces remaining “UNRESTRICTED” wording and unsupported Linux package claims
- adds a dependency-free `npm test` command using Node's built-in test runner
- runs the suite in CI

## Coverage

The 22 tests cover local document behavior, private-network blocking, DNS pinning and rebinding resistance, original Host preservation, redirect validation, declared/streamed size caps, Web and Node streams, fail-closed unstreamable bodies, timeout propagation, frontend request shapes, response-envelope unwrapping, network failures, and the explicit 501 sandbox explanation.

## Validation

- all changed Node/CommonJS files pass `node --check`
- `npm test` — 22 passed locally
- `npm run build` — Vite production build passed locally
- readiness-helper success and timeout paths passed locally
- `git diff --check`

The five actionable CodeRabbit findings from the first review have been addressed in the latest commits.